### PR TITLE
Implement offender photo upload and expanded history

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -64,10 +64,10 @@
     <button onclick="location.href='/operador/listado_delincuentes.php';">
       <i class="fa-solid fa-user-group"></i> Delincuentes
     </button>
-    <button onclick="location.href='/operador/historial_delincuente.php';">
-      <i class="fa-solid fa-book"></i> Historial
-    </button>
   <?php endif; ?>
+  <button onclick="location.href='/operador/historial_delincuente.php';">
+    <i class="fa-solid fa-book"></i> Historial
+  </button>
   <button onclick="location.href='/reportes.php';">
     <i class="fa-solid fa-chart-simple"></i> Reportes
   </button>

--- a/operador/descargar_historial.php
+++ b/operador/descargar_historial.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
+if (!isset($_SESSION['rol']) || !in_array($_SESSION['rol'], ['admin','jefe_zona','operador'])) {
     header('Location: /login.php');
     exit;
 }
@@ -10,7 +10,7 @@ $rut = $_GET['rut'] ?? '';
 if (!$rut) {
     exit('RUT inválido');
 }
-$stmt = $pdo->prepare("SELECT created_at AS fecha, ultimo_lugar_visto, latitud, longitud FROM delincuente WHERE rut = ? ORDER BY created_at DESC");
+$stmt = $pdo->prepare("SELECT created_at AS fecha, imagen, rut, apellidos_nombres, apodo, domicilio, fono_fijo, celular, email, fecha_nacimiento, delitos, estado, ultimo_lugar_visto, latitud, longitud FROM delincuente WHERE rut = ? ORDER BY created_at DESC");
 $stmt->execute([$rut]);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -18,7 +18,7 @@ header('Content-Type: text/csv');
 header('Content-Disposition: attachment; filename="historial_'.$rut.'.csv"');
 
 $out = fopen('php://output', 'w');
-fputcsv($out, ['Fecha','UltimoLugar','Latitud','Longitud']);
+fputcsv($out, ['Fecha','Imagen','RUT','Nombre','Apodo','Domicilio','Fono','Celular','Email','FechaNacimiento','Delitos','Estado','UltimoLugar','Latitud','Longitud']);
 foreach ($rows as $r) {
     fputcsv($out, $r);
 }

--- a/operador/editar_delincuente.php
+++ b/operador/editar_delincuente.php
@@ -34,8 +34,9 @@ if (!$delincuente) {
 <div class="wrapper">
     <div class="content">
         <h2>Editar Delincuente</h2>
-        <form action="procesar_edicion_delincuente.php" method="post">
+        <form action="procesar_edicion_delincuente.php" method="post" enctype="multipart/form-data">
             <input type="hidden" name="id" value="<?= htmlspecialchars($delincuente['id']) ?>">
+            <input type="hidden" name="imagen_actual" value="<?= htmlspecialchars($delincuente['imagen']) ?>">
 
             <div class="form-group">
                 <label for="rut">RUT:</label>
@@ -68,6 +69,13 @@ if (!$delincuente) {
             <div class="form-group">
                 <label for="email">Email:</label>
                 <input type="email" id="email" name="email" value="<?= htmlspecialchars($delincuente['email']) ?>">
+            </div>
+            <div class="form-group">
+                <label for="imagen">Foto (opcional):</label>
+                <input type="file" id="imagen" name="imagen" accept="image/*">
+                <?php if ($delincuente['imagen']): ?>
+                  <br><img src="/<?= htmlspecialchars($delincuente['imagen']) ?>" style="max-width:150px;">
+                <?php endif; ?>
             </div>
             <div class="form-group">
                 <label for="fecha_nacimiento">Fecha de Nacimiento:</label>

--- a/operador/historial_delincuente.php
+++ b/operador/historial_delincuente.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
+if (!isset($_SESSION['rol']) || !in_array($_SESSION['rol'], ['admin','jefe_zona','operador'])) {
     header('Location: /login.php');
     exit;
 }
@@ -13,7 +13,7 @@ $lista = $pdo->query("SELECT DISTINCT rut, apellidos_nombres FROM delincuente OR
 $rut = $_GET['rut'] ?? '';
 $historial = [];
 if ($rut) {
-    $stmt = $pdo->prepare("SELECT ultimo_lugar_visto, latitud, longitud, created_at AS fecha FROM delincuente WHERE rut = ? ORDER BY created_at DESC");
+    $stmt = $pdo->prepare("SELECT imagen,rut,apellidos_nombres,apodo,domicilio,fono_fijo,celular,email,fecha_nacimiento,delitos,estado,ultimo_lugar_visto,latitud,longitud,created_at AS fecha FROM delincuente WHERE rut = ? ORDER BY created_at DESC");
     $stmt->execute([$rut]);
     $historial = $stmt->fetchAll();
 }
@@ -38,6 +38,17 @@ if ($rut) {
         <thead>
           <tr>
             <th>Fecha</th>
+            <th>Imagen</th>
+            <th>RUT</th>
+            <th>Nombre</th>
+            <th>Apodo</th>
+            <th>Domicilio</th>
+            <th>Fono</th>
+            <th>Celular</th>
+            <th>Email</th>
+            <th>Fecha Nac.</th>
+            <th>Delitos</th>
+            <th>Estado</th>
             <th>Último Lugar Visto</th>
             <th>Latitud</th>
             <th>Longitud</th>
@@ -47,6 +58,17 @@ if ($rut) {
           <?php foreach ($historial as $h): ?>
             <tr>
               <td><?= htmlspecialchars($h['fecha']) ?></td>
+              <td><?php if ($h['imagen']): ?><img src="/<?= htmlspecialchars($h['imagen']) ?>" style="width:50px;"><?php endif; ?></td>
+              <td><?= htmlspecialchars($h['rut']) ?></td>
+              <td><?= htmlspecialchars($h['apellidos_nombres']) ?></td>
+              <td><?= htmlspecialchars($h['apodo']) ?></td>
+              <td><?= htmlspecialchars($h['domicilio']) ?></td>
+              <td><?= htmlspecialchars($h['fono_fijo']) ?></td>
+              <td><?= htmlspecialchars($h['celular']) ?></td>
+              <td><?= htmlspecialchars($h['email']) ?></td>
+              <td><?= htmlspecialchars($h['fecha_nacimiento']) ?></td>
+              <td><?= htmlspecialchars($h['delitos']) ?></td>
+              <td><?= htmlspecialchars($h['estado']) ?></td>
               <td><?= htmlspecialchars($h['ultimo_lugar_visto']) ?></td>
               <td><?= htmlspecialchars($h['latitud']) ?></td>
               <td><?= htmlspecialchars($h['longitud']) ?></td>

--- a/operador/procesar_edicion_delincuente.php
+++ b/operador/procesar_edicion_delincuente.php
@@ -7,6 +7,19 @@ if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
 
 require_once '../config.php';
 
+$imagen = $_POST['imagen_actual'] ?? null;
+if (!empty($_FILES['imagen']['name'])) {
+    $dir = __DIR__ . '/../img/delincuentes/';
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $ext = pathinfo($_FILES['imagen']['name'], PATHINFO_EXTENSION);
+    $nombreArchivo = uniqid('delinc_', true) . '.' . $ext;
+    if (move_uploaded_file($_FILES['imagen']['tmp_name'], $dir . $nombreArchivo)) {
+        $imagen = 'img/delincuentes/' . $nombreArchivo;
+    }
+}
+
 $sql = "UPDATE delincuente SET
             rut = :rut,
             apellidos_nombres = :nombre,
@@ -16,6 +29,7 @@ $sql = "UPDATE delincuente SET
             fono_fijo = :fono,
             celular = :celular,
             email = :email,
+            imagen = :imagen,
             fecha_nacimiento = :fecha_nacimiento,
             delitos = :delitos,
             estado = :estado,
@@ -33,6 +47,7 @@ $stmt->execute([
     'fono' => $_POST['fono'],
     'celular' => $_POST['celular'],
     'email' => $_POST['email'],
+    'imagen' => $imagen,
     'fecha_nacimiento' => $_POST['fecha_nacimiento'],
     'delitos' => isset($_POST['delitos']) ? implode(',', $_POST['delitos']) : '',
     'estado' => $_POST['estado'],

--- a/operador/process_registro_delincuente.php
+++ b/operador/process_registro_delincuente.php
@@ -24,6 +24,7 @@ $datos = [
   'fono'            => trim($_POST['fono']),
   'celular'         => trim($_POST['celular']),
   'email'           => trim($_POST['email']),
+  'imagen'          => null,
   'fecha_nacimiento'=> $_POST['fecha_nacimiento'],
   'delitos'         => isset($_POST['delitos']) ? implode(',', $_POST['delitos']) : '',
   'estado'          => $_POST['estado'],
@@ -31,14 +32,27 @@ $datos = [
   'longitud'        => trim($_POST['longitud']),
 ];
 
+// Procesar la imagen subida
+if (!empty($_FILES['imagen']['name'])) {
+  $dir = __DIR__ . '/../img/delincuentes/';
+  if (!is_dir($dir)) {
+    mkdir($dir, 0755, true);
+  }
+  $ext = pathinfo($_FILES['imagen']['name'], PATHINFO_EXTENSION);
+  $nombreArchivo = uniqid('delinc_', true) . '.' . $ext;
+  if (move_uploaded_file($_FILES['imagen']['tmp_name'], $dir . $nombreArchivo)) {
+    $datos['imagen'] = 'img/delincuentes/' . $nombreArchivo;
+  }
+}
+
 
 $sql="INSERT INTO delincuente
     (rut,apellidos_nombres,apodo,domicilio,ultimo_lugar_visto,
-     fono_fijo,celular,email,fecha_nacimiento,delitos,estado,
+     fono_fijo,celular,email,imagen,fecha_nacimiento,delitos,estado,
      latitud,longitud)
   VALUES
     (:rut,:nombre,:apodo,:domicilio,:ultimo_lugar,
-     :fono,:celular,:email,:fecha_nacimiento,:delitos,:estado,
+     :fono,:celular,:email,:imagen,:fecha_nacimiento,:delitos,:estado,
      :latitud,:longitud)
 ";
 $insert=$pdo->prepare($sql);

--- a/operador/registro_delincuente.php
+++ b/operador/registro_delincuente.php
@@ -16,7 +16,7 @@ $tiposDelito = $stmtTipos->fetchAll();
   <div class="content">
     <h2>Registro de Delincuentes</h2>
     <?php if (isset($_GET['msg'])) echo "<p class='msg'>" . htmlspecialchars($_GET['msg']) . "</p>"; ?>
-    <form action="process_registro_delincuente.php" method="post">
+    <form action="process_registro_delincuente.php" method="post" enctype="multipart/form-data">
       <div class="form-group">
         <label for="rut">RUT:</label>
         <input id="rut" name="rut" required>
@@ -48,6 +48,10 @@ $tiposDelito = $stmtTipos->fetchAll();
       <div class="form-group">
         <label for="email">Email:</label>
         <input type="email" id="email" name="email">
+      </div>
+      <div class="form-group">
+        <label for="imagen">Foto (opcional):</label>
+        <input type="file" id="imagen" name="imagen" accept="image/*">
       </div>
       <div class="form-group">
         <label for="fecha_nacimiento">Fecha de Nacimiento:</label>

--- a/schema.sql
+++ b/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS delincuente (
   fono_fijo VARCHAR(20),
   celular VARCHAR(20),
   email VARCHAR(100),
+  imagen VARCHAR(255),
   fecha_nacimiento DATE,
   delitos TEXT,
   estado ENUM('P','L','A') NOT NULL,


### PR DESCRIPTION
## Summary
- allow uploading an optional photo when registering or editing an offender
- store uploaded photo path in database
- include `imagen` column in schema
- show detailed offender history with all fields and picture
- export complete history data to CSV
- make history page accessible to all roles
- update sidebar to show history link for any user

## Testing
- `php -l operador/process_registro_delincuente.php`
- `php -l operador/procesar_edicion_delincuente.php`
- `php -l operador/descargar_historial.php`
- `php -l operador/historial_delincuente.php`
- `php -l operador/registro_delincuente.php`
- `php -l operador/editar_delincuente.php`
- `php -l inc/header.php`

------
https://chatgpt.com/codex/tasks/task_e_685d70ad1a8c8326a18546548a7394c4