### PR TITLE
Implement police control records

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -64,6 +64,9 @@
     <button onclick="location.href='/operador/listado_delincuentes.php';">
       <i class="fa-solid fa-user-group"></i> Delincuentes
     </button>
+    <button onclick="location.href='/operador/registro_control.php';">
+      <i class="fa-solid fa-clipboard"></i> Registrar Control
+    </button>
   <?php endif; ?>
   <button onclick="location.href='/operador/historial_delincuente.php';">
     <i class="fa-solid fa-book"></i> Historial

--- a/operador/process_registro_control.php
+++ b/operador/process_registro_control.php
@@ -1,0 +1,59 @@
+<?php
+// operador/process_registro_control.php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'operador') {
+  header("Location: ../index.php");
+  exit();
+}
+require_once '../config.php';
+require_once '../inc/funciones.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  header('Location: registro_control.php');
+  exit();
+}
+
+$tipo = $_POST['tipo'] ?? '';
+if (!$tipo) {
+  header('Location: registro_control.php?msg=Tipo%20requerido');
+  exit();
+}
+
+$data = [
+  'operador_id' => $_SESSION['user_id'],
+  'tipo' => $tipo,
+  'rut' => trim($_POST['rut'] ?? ''),
+  'nombre' => trim($_POST['nombre'] ?? ''),
+  'motivo_desplazamiento' => trim($_POST['motivo_desplazamiento'] ?? ''),
+  'ubicacion' => trim($_POST['ubicacion'] ?? ''),
+  'latitud' => $_POST['latitud'] !== '' ? $_POST['latitud'] : null,
+  'longitud' => $_POST['longitud'] !== '' ? $_POST['longitud'] : null,
+  'observacion' => trim($_POST['observacion'] ?? ''),
+  'licencia_conducir' => trim($_POST['licencia_conducir'] ?? ''),
+  'padron_vehiculo' => trim($_POST['padron_vehiculo'] ?? ''),
+  'revision_seguro' => trim($_POST['revision_seguro'] ?? ''),
+  'rut_conductor' => trim($_POST['rut_conductor'] ?? ''),
+  'nombre_conductor' => trim($_POST['nombre_conductor'] ?? ''),
+  'pertenencias' => trim($_POST['pertenencias'] ?? ''),
+  'permisos_arma' => trim($_POST['permisos_arma'] ?? ''),
+  'revision_mochila' => trim($_POST['revision_mochila'] ?? ''),
+  'test_alcoholemia' => trim($_POST['test_alcoholemia'] ?? ''),
+  'doc_vehicular' => trim($_POST['doc_vehicular'] ?? '')
+];
+
+$sql = "INSERT INTO control_policial
+          (operador_id,tipo,rut,nombre,motivo_desplazamiento,ubicacion,latitud,longitud,observacion,
+           licencia_conducir,padron_vehiculo,revision_seguro,rut_conductor,nombre_conductor,
+           pertenencias,permisos_arma,revision_mochila,test_alcoholemia,doc_vehicular)
+        VALUES
+          (:operador_id,:tipo,:rut,:nombre,:motivo_desplazamiento,:ubicacion,:latitud,:longitud,:observacion,
+           :licencia_conducir,:padron_vehiculo,:revision_seguro,:rut_conductor,:nombre_conductor,
+           :pertenencias,:permisos_arma,:revision_mochila,:test_alcoholemia,:doc_vehicular)";
+$stmt = $pdo->prepare($sql);
+if ($stmt->execute($data)) {
+  header('Location: registro_control.php?msg=Control%20registrado');
+  exit();
+} else {
+  header('Location: registro_control.php?msg=Error');
+  exit();
+}

--- a/operador/registro_control.php
+++ b/operador/registro_control.php
@@ -1,0 +1,122 @@
+<?php
+// operador/registro_control.php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'operador') {
+  header("Location: ../index.php");
+  exit();
+}
+require_once '../config.php';
+?>
+<?php include('../inc/header.php'); ?>
+<div class="wrapper">
+  <div class="content">
+    <h2>Registro de Control Policial</h2>
+    <?php if (isset($_GET['msg'])) echo "<p class='msg'>".htmlspecialchars($_GET['msg'])."</p>"; ?>
+    <form action="process_registro_control.php" method="post" id="frmControl">
+      <div class="form-group">
+        <label for="tipo">Tipo de Control:</label>
+        <select id="tipo" name="tipo" required>
+          <option value="">-- Seleccione --</option>
+          <option value="identidad">Control de Identidad</option>
+          <option value="vehicular">Control Vehicular</option>
+          <option value="armas_drogas">Control Preventivo de Armas o Drogas</option>
+          <option value="transito">Control de Tránsito</option>
+        </select>
+      </div>
+
+      <div id="seccion-identidad" class="tipo-section" style="display:none;">
+        <div class="form-group">
+          <label for="rut">RUT:</label>
+          <input id="rut" name="rut">
+        </div>
+        <div class="form-group">
+          <label for="nombre">Nombre Completo:</label>
+          <input id="nombre" name="nombre">
+        </div>
+        <div class="form-group">
+          <label for="motivo_desplazamiento">Motivo de Desplazamiento:</label>
+          <input id="motivo_desplazamiento" name="motivo_desplazamiento">
+        </div>
+        <div class="form-group">
+          <label for="ubicacion">Ubicación:</label>
+          <input id="ubicacion" name="ubicacion">
+        </div>
+        <div class="form-group">
+          <label for="latitud">Latitud:</label>
+          <input id="latitud" name="latitud">
+        </div>
+        <div class="form-group">
+          <label for="longitud">Longitud:</label>
+          <input id="longitud" name="longitud">
+        </div>
+        <div class="form-group">
+          <label for="observacion">Observación:</label>
+          <textarea id="observacion" name="observacion"></textarea>
+        </div>
+      </div>
+
+      <div id="seccion-vehicular" class="tipo-section" style="display:none;">
+        <div class="form-group">
+          <label for="licencia_conducir">Licencia de Conducir:</label>
+          <input id="licencia_conducir" name="licencia_conducir">
+        </div>
+        <div class="form-group">
+          <label for="padron_vehiculo">Padrón del Vehículo:</label>
+          <input id="padron_vehiculo" name="padron_vehiculo">
+        </div>
+        <div class="form-group">
+          <label for="revision_seguro">Revisión Técnica / SOAP:</label>
+          <input id="revision_seguro" name="revision_seguro">
+        </div>
+        <div class="form-group">
+          <label for="rut_conductor">RUT del Conductor:</label>
+          <input id="rut_conductor" name="rut_conductor">
+        </div>
+        <div class="form-group">
+          <label for="nombre_conductor">Nombre del Conductor:</label>
+          <input id="nombre_conductor" name="nombre_conductor">
+        </div>
+      </div>
+
+      <div id="seccion-armas" class="tipo-section" style="display:none;">
+        <div class="form-group">
+          <label for="pertenencias">Pertenencias:</label>
+          <textarea id="pertenencias" name="pertenencias"></textarea>
+        </div>
+        <div class="form-group">
+          <label for="permisos_arma">Permisos de Arma:</label>
+          <input id="permisos_arma" name="permisos_arma">
+        </div>
+        <div class="form-group">
+          <label for="revision_mochila">Revisión de Vehículo/Mochila:</label>
+          <textarea id="revision_mochila" name="revision_mochila"></textarea>
+        </div>
+      </div>
+
+      <div id="seccion-transito" class="tipo-section" style="display:none;">
+        <div class="form-group">
+          <label for="test_alcoholemia">Test de Alcoholemia/Narcotest:</label>
+          <input id="test_alcoholemia" name="test_alcoholemia">
+        </div>
+        <div class="form-group">
+          <label for="doc_vehicular">Documentación Vehicular y del Conductor:</label>
+          <textarea id="doc_vehicular" name="doc_vehicular"></textarea>
+        </div>
+      </div>
+
+      <button type="submit">Registrar Control</button>
+    </form>
+  </div>
+  <?php include('../inc/footer.php'); ?>
+</div>
+
+<script>
+  document.getElementById('tipo').addEventListener('change', function() {
+    document.querySelectorAll('.tipo-section').forEach(s => s.style.display = 'none');
+    const val = this.value;
+    if (val === 'identidad') document.getElementById('seccion-identidad').style.display = 'block';
+    else if (val === 'vehicular') document.getElementById('seccion-vehicular').style.display = 'block';
+    else if (val === 'armas_drogas') document.getElementById('seccion-armas').style.display = 'block';
+    else if (val === 'transito') document.getElementById('seccion-transito').style.display = 'block';
+  });
+</script>

--- a/schema.sql
+++ b/schema.sql
@@ -90,3 +90,30 @@ CREATE TABLE IF NOT EXISTS operador (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (institucion_id) REFERENCES institucion(id) ON DELETE SET NULL
 );
+
+# New table for police controls
+
+CREATE TABLE IF NOT EXISTS control_policial (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  operador_id INT DEFAULT NULL,
+  tipo ENUM('identidad','vehicular','armas_drogas','transito') NOT NULL,
+  rut VARCHAR(12),
+  nombre VARCHAR(150),
+  motivo_desplazamiento TEXT,
+  ubicacion VARCHAR(200),
+  latitud DECIMAL(10,7) DEFAULT NULL,
+  longitud DECIMAL(10,7) DEFAULT NULL,
+  observacion TEXT,
+  licencia_conducir VARCHAR(100),
+  padron_vehiculo VARCHAR(100),
+  revision_seguro VARCHAR(100),
+  rut_conductor VARCHAR(12),
+  nombre_conductor VARCHAR(150),
+  pertenencias TEXT,
+  permisos_arma TEXT,
+  revision_mochila TEXT,
+  test_alcoholemia VARCHAR(100),
+  doc_vehicular TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (operador_id) REFERENCES operador(id) ON DELETE SET NULL
+);


### PR DESCRIPTION
## Summary
- allow operators to add police control records
- display form fields based on control type
- save controls via new `control_policial` table
- add menu link for registering controls

## Testing
- `php -l operador/registro_control.php`
- `php -l operador/process_registro_control.php`
- `php -l inc/header.php`


------
https://chatgpt.com/codex/tasks/task_e_685de60784608326af61568fed407c3b