### PR TITLE
Restrict deletions to admin

### DIFF
--- a/jefe/eliminar_sector.php
+++ b/jefe/eliminar_sector.php
@@ -1,7 +1,7 @@
 <?php
 // jefe/eliminar_sector.php
 session_start();
-if (!isset($_SESSION['user_id'])||$_SESSION['rol']!=='jefe_zona'){
+if (!isset($_SESSION['user_id'])||$_SESSION['rol']!=='admin'){
   header("Location: ../index.php");exit();
 }
 require_once '../config.php';

--- a/jefe/gestion_sectores.php
+++ b/jefe/gestion_sectores.php
@@ -28,8 +28,9 @@ $iid=$_SESSION['institucion_id'];
           <td><?php echo htmlspecialchars($s['descripcion']);?></td>
           <td>
             <button onclick="location.href='editar_sector.php?id=<?php echo $s['id'];?>'">Editar</button>
-            <button onclick="if(confirm('¿Seguro?')) location.href=
-              'eliminar_sector.php?id=<?php echo $s['id'];?>'">Eliminar</button>
+            <?php if (!empty($_SESSION['rol']) && $_SESSION['rol'] === 'admin'): ?>
+            <button onclick="if(confirm('¿Seguro?')) location.href='eliminar_sector.php?id=<?php echo $s['id'];?>'">Eliminar</button>
+            <?php endif; ?>
           </td>
         </tr>
         <?php endwhile;?>

--- a/operador/eliminar_delincuente.php
+++ b/operador/eliminar_delincuente.php
@@ -1,6 +1,6 @@
 <?php
 session_start();
-if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
+if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'admin') {
     header('Location: /login.php');
     exit;
 }

--- a/operador/listado_delincuentes.php
+++ b/operador/listado_delincuentes.php
@@ -113,10 +113,12 @@ $delincuentes = $stmt->fetchAll();
               <a href="editar_delincuente.php?id=<?= htmlspecialchars($row['id']) ?>">
                 <button>Editar</button>
               </a>
-              <form method="POST" action="eliminar_delincuente.php" style="display:inline;" onsubmit="return confirm('¿Estás seguro de que deseas eliminar este registro?');">
-                <input type="hidden" name="id" value="<?= htmlspecialchars($row['id']) ?>">
-                <button type="submit" style="background-color:red; color:white;">Eliminar</button>
-              </form>
+              <?php if (!empty($_SESSION['rol']) && $_SESSION['rol'] === 'admin'): ?>
+                <form method="POST" action="eliminar_delincuente.php" style="display:inline;" onsubmit="return confirm('¿Estás seguro de que deseas eliminar este registro?');">
+                  <input type="hidden" name="id" value="<?= htmlspecialchars($row['id']) ?>">
+                  <button type="submit" style="background-color:red; color:white;">Eliminar</button>
+                </form>
+              <?php endif; ?>
             </td>
           </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- hide delete button in operator listing unless the user is an admin
- hide sector deletion unless the user is an admin
- restrict delinquent and sector deletion endpoints to admins

## Testing
- `php -l operador/listado_delincuentes.php`
- `php -l jefe/gestion_sectores.php`
- `php -l operador/eliminar_delincuente.php`
- `php -l jefe/eliminar_sector.php`


------
https://chatgpt.com/codex/tasks/task_e_685e04e087188326b3a8c75a4b189379