### PR TITLE
Add validation for numeric inputs and string length

### DIFF
--- a/operador/process_registro_control.php
+++ b/operador/process_registro_control.php
@@ -41,6 +41,34 @@ $data = [
   'doc_vehicular' => trim($_POST['doc_vehicular'] ?? '')
 ];
 
+// Validaciones
+if ($data['latitud'] !== null && !is_numeric($data['latitud'])) {
+  header('Location: registro_control.php?msg=Latitud%20inv\xE1lida');
+  exit();
+}
+if ($data['longitud'] !== null && !is_numeric($data['longitud'])) {
+  header('Location: registro_control.php?msg=Longitud%20inv\xE1lida');
+  exit();
+}
+
+$limites = [
+  'rut' => 12,
+  'nombre' => 150,
+  'ubicacion' => 200,
+  'licencia_conducir' => 100,
+  'padron_vehiculo' => 100,
+  'revision_seguro' => 100,
+  'rut_conductor' => 12,
+  'nombre_conductor' => 150,
+  'test_alcoholemia' => 100
+];
+foreach ($limites as $campo => $max) {
+  if (!empty($data[$campo]) && mb_strlen($data[$campo]) > $max) {
+    header('Location: registro_control.php?msg=' . $campo . '%20muy%20largo');
+    exit();
+  }
+}
+
 $sql = "INSERT INTO control_policial
           (operador_id,tipo,rut,nombre,motivo_desplazamiento,ubicacion,latitud,longitud,observacion,
            licencia_conducir,padron_vehiculo,revision_seguro,rut_conductor,nombre_conductor,

--- a/operador/process_registro_delincuente.php
+++ b/operador/process_registro_delincuente.php
@@ -38,6 +38,33 @@ $datos = [
   'longitud'        => trim($_POST['longitud']),
 ];
 
+// Validaciones de formato y longitud
+if ($datos['fono'] !== '' && !ctype_digit($datos['fono'])) {
+  header("Location: registro_delincuente.php?msg=Fono debe ser numérico"); exit();
+}
+if ($datos['celular'] !== '' && !ctype_digit($datos['celular'])) {
+  header("Location: registro_delincuente.php?msg=Celular debe ser numérico"); exit();
+}
+if (!is_numeric($datos['latitud']) || !is_numeric($datos['longitud'])) {
+  header("Location: registro_delincuente.php?msg=Coordenadas inválidas"); exit();
+}
+
+if (mb_strlen($datos['nombre']) > 150) {
+  header("Location: registro_delincuente.php?msg=Nombre muy largo"); exit();
+}
+if (mb_strlen($datos['apodo']) > 50) {
+  header("Location: registro_delincuente.php?msg=Apodo muy largo"); exit();
+}
+if (mb_strlen($datos['domicilio']) > 200) {
+  header("Location: registro_delincuente.php?msg=Domicilio muy largo"); exit();
+}
+if (mb_strlen($datos['ultimo_lugar']) > 200) {
+  header("Location: registro_delincuente.php?msg=Último lugar muy largo"); exit();
+}
+if (mb_strlen($datos['email']) > 100) {
+  header("Location: registro_delincuente.php?msg=Email muy largo"); exit();
+}
+
 // Procesar la imagen subida
 if (!empty($_FILES['imagen']['name'])) {
   $dir = __DIR__ . '/../img/delincuentes/';

--- a/process_login.php
+++ b/process_login.php
@@ -14,7 +14,16 @@ if (!validarRut($rut)) {
     header("Location: index.php?error=RUT inválido");
     exit();
 }
+$cleanRut = limpiarRut($rut);
+if (strlen($cleanRut) > 12) {
+    header("Location: index.php?error=RUT demasiado largo");
+    exit();
+}
 $password = $_POST['password'];
+if (strlen($password) > 100) {
+    header("Location: index.php?error=Contraseña demasiado larga");
+    exit();
+}
 
 $sql  = "SELECT * FROM usuario WHERE rut = :rut";
 $stmt = $pdo->prepare($sql);


### PR DESCRIPTION
## Summary
- enforce value ranges when registering criminals
- validate control_policial inputs
- guard login with length checks

## Testing
- `php -l operador/process_registro_delincuente.php`
- `php -l operador/process_registro_control.php`
- `php -l process_login.php`


------
https://chatgpt.com/codex/tasks/task_e_685e0503634c83268d8a265b126f71c0