### PR TITLE
Use usuario for police controls

### DIFF
--- a/operador/process_registro_control.php
+++ b/operador/process_registro_control.php
@@ -20,7 +20,7 @@ if (!$tipo) {
 }
 
 $data = [
-  'operador_id' => $_SESSION['user_id'],
+  'usuario_id' => $_SESSION['user_id'],
   'tipo' => $tipo,
   'rut' => trim($_POST['rut'] ?? ''),
   'nombre' => trim($_POST['nombre'] ?? ''),
@@ -42,11 +42,11 @@ $data = [
 ];
 
 $sql = "INSERT INTO control_policial
-          (operador_id,tipo,rut,nombre,motivo_desplazamiento,ubicacion,latitud,longitud,observacion,
+          (usuario_id,tipo,rut,nombre,motivo_desplazamiento,ubicacion,latitud,longitud,observacion,
            licencia_conducir,padron_vehiculo,revision_seguro,rut_conductor,nombre_conductor,
            pertenencias,permisos_arma,revision_mochila,test_alcoholemia,doc_vehicular)
         VALUES
-          (:operador_id,:tipo,:rut,:nombre,:motivo_desplazamiento,:ubicacion,:latitud,:longitud,:observacion,
+          (:usuario_id,:tipo,:rut,:nombre,:motivo_desplazamiento,:ubicacion,:latitud,:longitud,:observacion,
            :licencia_conducir,:padron_vehiculo,:revision_seguro,:rut_conductor,:nombre_conductor,
            :pertenencias,:permisos_arma,:revision_mochila,:test_alcoholemia,:doc_vehicular)";
 $stmt = $pdo->prepare($sql);

--- a/schema.sql
+++ b/schema.sql
@@ -81,21 +81,11 @@ ALTER TABLE delito
   ADD FOREIGN KEY (tipo_id) REFERENCES tipo_delito(id) ON DELETE SET NULL,
   ADD FOREIGN KEY (delincuente_id) REFERENCES delincuente(id) ON DELETE SET NULL;
 
-CREATE TABLE IF NOT EXISTS operador (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  rut VARCHAR(12) NOT NULL UNIQUE,
-  password VARCHAR(255) NOT NULL,
-  apellidos_nombres VARCHAR(150) NOT NULL,
-  institucion_id INT DEFAULT NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (institucion_id) REFERENCES institucion(id) ON DELETE SET NULL
-);
-
 # New table for police controls
 
 CREATE TABLE IF NOT EXISTS control_policial (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  operador_id INT DEFAULT NULL,
+  usuario_id INT DEFAULT NULL,
   tipo ENUM('identidad','vehicular','armas_drogas','transito') NOT NULL,
   rut VARCHAR(12),
   nombre VARCHAR(150),
@@ -115,5 +105,5 @@ CREATE TABLE IF NOT EXISTS control_policial (
   test_alcoholemia VARCHAR(100),
   doc_vehicular TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (operador_id) REFERENCES operador(id) ON DELETE SET NULL
+  FOREIGN KEY (usuario_id) REFERENCES usuario(id) ON DELETE SET NULL
 );


### PR DESCRIPTION
## Summary
- remove unused `operador` table
- reference `usuario` from `control_policial`
- update operator control recording code

## Testing
- `php -l operador/process_registro_control.php`
- `php -l schema.sql`


------
https://chatgpt.com/codex/tasks/task_e_685e0b7f68f883269ec09e9b095e5605