### PR TITLE
Refactor config to use environment variables

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,10 +1,20 @@
 <?php
 // config.php
-$host   = 'localhost';
-$db     = 'sipc2';
-$user   = 'root';
-$pass   = 'Hola.,123';
-$charset= 'utf8mb4';
+$charset = 'utf8mb4';
+
+function getEnvOrMessage($var, $message) {
+    $val = getenv($var);
+    if ($val === false || $val === '') {
+        trigger_error($message, E_USER_WARNING);
+        return '';
+    }
+    return $val;
+}
+
+$host = getEnvOrMessage('DB_HOST', 'Environment variable DB_HOST is missing.');
+$db   = getEnvOrMessage('DB_NAME', 'Environment variable DB_NAME is missing.');
+$user = getEnvOrMessage('DB_USER', 'Environment variable DB_USER is missing.');
+$pass = getEnvOrMessage('DB_PASS', 'Environment variable DB_PASS is missing.');
 
 $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
 $options = [


### PR DESCRIPTION
## Summary
- load database credentials from environment variables
- warn when required environment variables are missing

## Testing
- `php -l config.php`

------
https://chatgpt.com/codex/tasks/task_e_685e0b801b888326bf10bf472d8c5996