### PR TITLE
Improve crime entry forms

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -111,4 +111,18 @@ document.addEventListener("DOMContentLoaded", () => {
       });
     }
   }
+
+  // Autocompletar lat/lon al seleccionar comuna
+  const comunaSelect = document.getElementById('comuna');
+  const latField = document.getElementById('latitud');
+  const lngField = document.getElementById('longitud');
+  if (comunaSelect && latField && lngField) {
+    comunaSelect.addEventListener('change', () => {
+      const opt = comunaSelect.selectedOptions[0];
+      if (opt) {
+        latField.value = opt.dataset.lat || '';
+        lngField.value = opt.dataset.lng || '';
+      }
+    });
+  }
 });

--- a/operador/editar_delincuente.php
+++ b/operador/editar_delincuente.php
@@ -7,8 +7,7 @@ if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
 
 require_once '../config.php';
 
-// Tipos de delito
-$stmtTipos = $pdo->query("SELECT nombre FROM tipo_delito ORDER BY nombre");
+$stmtTipos = $pdo->query("SELECT nombre, descripcion FROM tipo_delito ORDER BY nombre");
 $tiposDelito = $stmtTipos->fetchAll();
 
 $id = $_GET['id'] ?? null;
@@ -86,7 +85,7 @@ if (!$delincuente) {
                 <select id="delitos" name="delitos[]" multiple>
                     <?php foreach ($tiposDelito as $t): ?>
                         <option value="<?= htmlspecialchars($t['nombre']) ?>" <?= in_array($t['nombre'], $selectedDelitos) ? 'selected' : '' ?>>
-                            <?= htmlspecialchars($t['nombre']) ?>
+                            <?= htmlspecialchars($t['nombre'] . ' - ' . $t['descripcion']) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/operador/registro_delincuente.php
+++ b/operador/registro_delincuente.php
@@ -8,7 +8,7 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'operador') {
 require_once '../config.php';
 
 // Obtener tipos de delitos desde la base de datos
-$stmtTipos = $pdo->query("SELECT nombre FROM tipo_delito ORDER BY nombre");
+$stmtTipos = $pdo->query("SELECT nombre, descripcion FROM tipo_delito ORDER BY nombre");
 $tiposDelito = $stmtTipos->fetchAll();
 ?>
 <?php include('../inc/header.php'); ?>
@@ -62,7 +62,7 @@ $tiposDelito = $stmtTipos->fetchAll();
         <select id="delitos" name="delitos[]" multiple>
           <?php foreach ($tiposDelito as $t): ?>
             <option value="<?= htmlspecialchars($t['nombre']) ?>">
-              <?= htmlspecialchars($t['nombre']) ?>
+              <?= htmlspecialchars($t['nombre'] . ' - ' . $t['descripcion']) ?>
             </option>
           <?php endforeach; ?>
         </select>

--- a/operador/registro_delito.php
+++ b/operador/registro_delito.php
@@ -7,9 +7,13 @@ if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'operador') {
 }
 require_once '../config.php';
 
-// Obtener tipos de delito
-$stmtTipos = $pdo->query("SELECT id, nombre FROM tipo_delito ORDER BY nombre");
+// Obtener tipos de delito con su descripción
+$stmtTipos = $pdo->query("SELECT id, nombre, descripcion FROM tipo_delito ORDER BY nombre");
 $tipos = $stmtTipos->fetchAll();
+
+// Obtener comunas para selector
+$stmtComunas = $pdo->query("SELECT nombre, latitud, longitud FROM comuna ORDER BY nombre");
+$comunas = $stmtComunas->fetchAll();
 
 // Obtener delincuentes existentes para asociar (opcional)
 $stmtDelincuentes = $pdo->query("SELECT id, rut, apellidos_nombres FROM delincuente ORDER BY apellidos_nombres");
@@ -31,7 +35,14 @@ $delincuentes = $stmtDelincuentes->fetchAll();
       </div>
       <div class="form-group">
         <label for="comuna">Comuna:</label>
-        <input id="comuna" name="comuna" required>
+        <select id="comuna" name="comuna" required>
+          <option value="">-- Seleccione --</option>
+          <?php foreach ($comunas as $c): ?>
+            <option value="<?= htmlspecialchars($c['nombre']) ?>" data-lat="<?= htmlspecialchars($c['latitud']) ?>" data-lng="<?= htmlspecialchars($c['longitud']) ?>">
+              <?= htmlspecialchars($c['nombre']) ?>
+            </option>
+          <?php endforeach; ?>
+        </select>
       </div>
       <div class="form-group">
         <label for="sector">Sector:</label>
@@ -55,7 +66,7 @@ $delincuentes = $stmtDelincuentes->fetchAll();
           <option value="">-- Seleccione --</option>
           <?php foreach ($tipos as $t): ?>
             <option value="<?= htmlspecialchars($t['id']) ?>">
-              <?= htmlspecialchars($t['nombre']) ?>
+              <?= htmlspecialchars($t['nombre'] . ' - ' . $t['descripcion']) ?>
             </option>
           <?php endforeach; ?>
         </select>

--- a/schema.sql
+++ b/schema.sql
@@ -62,6 +62,18 @@ INSERT INTO tipo_delito (nombre, descripcion) VALUES
   ('Asalto', 'Ataque violento contra personas o propiedades'),
   ('Homicidio', 'Crimen que resulta en la muerte de una persona');
 
+CREATE TABLE IF NOT EXISTS comuna (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(100) NOT NULL UNIQUE,
+  latitud DECIMAL(10,7) DEFAULT NULL,
+  longitud DECIMAL(10,7) DEFAULT NULL
+);
+
+INSERT INTO comuna (nombre, latitud, longitud) VALUES
+  ('Santiago', -33.4489, -70.6693),
+  ('Providencia', -33.4263, -70.6159),
+  ('La Florida', -33.5235, -70.6095);
+
 CREATE TABLE IF NOT EXISTS delito (
   id INT AUTO_INCREMENT PRIMARY KEY,
   codigo VARCHAR(50) NOT NULL UNIQUE,


### PR DESCRIPTION
## Summary
- add `comuna` catalog with coordinates
- show delito descriptions in selects
- replace comuna text input with select and auto-fill lat/lng
- enable same delito description display on delincuente forms
- auto-populate coordinates when comuna changes

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685efe27646c8326a8b1ebfc89ded7d6