### PR TITLE
Fix ambiguous column error in historial queries

### DIFF
--- a/operador/descargar_historial.php
+++ b/operador/descargar_historial.php
@@ -17,7 +17,7 @@ $persona = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$persona) {
     exit('RUT inválido');
 }
-$sql = "SELECT fecha, td.nombre AS tipo, descripcion, comuna, sector, latitud, longitud
+$sql = "SELECT fecha, td.nombre AS tipo, dl.descripcion, comuna, sector, latitud, longitud
         FROM delito dl
         LEFT JOIN tipo_delito td ON dl.tipo_id = td.id
         WHERE dl.delincuente_id = ? ORDER BY fecha DESC";

--- a/operador/historial_delincuente.php
+++ b/operador/historial_delincuente.php
@@ -18,7 +18,7 @@ if ($rut) {
     $stmt->execute([$rut]);
     $persona = $stmt->fetch();
     if ($persona) {
-        $sql = "SELECT fecha, td.nombre AS tipo, descripcion, comuna, sector, latitud, longitud
+        $sql = "SELECT fecha, td.nombre AS tipo, dl.descripcion, comuna, sector, latitud, longitud
                 FROM delito dl
                 LEFT JOIN tipo_delito td ON dl.tipo_id = td.id
                 WHERE dl.delincuente_id = ? ORDER BY fecha DESC";


### PR DESCRIPTION
## Summary
- specify the correct table for `descripcion` when fetching crimes

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6861aaf4221883269ab33fc82e9639a3