### PR TITLE
Fix map address autofill

### DIFF
--- a/operador/editar_delincuente.php
+++ b/operador/editar_delincuente.php
@@ -158,6 +158,18 @@ if (!$delincuente) {
     const geocoder = new google.maps.Geocoder();
     const autocomplete = new google.maps.places.Autocomplete(addressInput);
 
+    function reverseGeocodeOSM(lat, lng) {
+      const url = `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lng}`;
+      fetch(url)
+        .then(r => r.json())
+        .then(data => {
+          if (data && data.display_name) {
+            addressInput.value = data.display_name;
+          }
+        })
+        .catch(() => {});
+    }
+
     function updatePosition(location) {
       const lat = location.lat();
       const lng = location.lng();
@@ -168,6 +180,8 @@ if (!$delincuente) {
       geocoder.geocode({ location: { lat, lng } }, (results, status) => {
         if (status === "OK" && results[0]) {
           addressInput.value = results[0].formatted_address;
+        } else {
+          reverseGeocodeOSM(lat, lng);
         }
       });
     }

--- a/operador/registro_delincuente.php
+++ b/operador/registro_delincuente.php
@@ -126,6 +126,18 @@ $tiposDelito = $stmtTipos->fetchAll();
       const geocoder = new google.maps.Geocoder();
       const autocomplete = new google.maps.places.Autocomplete(addressInput);
 
+      function reverseGeocodeOSM(lat, lng) {
+        const url = `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${lat}&lon=${lng}`;
+        fetch(url)
+          .then(r => r.json())
+          .then(data => {
+            if (data && data.display_name) {
+              addressInput.value = data.display_name;
+            }
+          })
+          .catch(() => {});
+      }
+
       function updatePosition(location) {
         const lat = location.lat();
         const lng = location.lng();
@@ -136,6 +148,8 @@ $tiposDelito = $stmtTipos->fetchAll();
         geocoder.geocode({ location: { lat, lng } }, (results, status) => {
           if (status === "OK" && results[0]) {
             addressInput.value = results[0].formatted_address;
+          } else {
+            reverseGeocodeOSM(lat, lng);
           }
         });
       }


### PR DESCRIPTION
## Summary
- add fallback reverse geocoding via OpenStreetMap
- use fallback in both register and edit pages

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_686434716488832687e076cbce6b4947