### PR TITLE
Fix duplicate placeholder in controls search

### DIFF
--- a/operador/ver_controles.php
+++ b/operador/ver_controles.php
@@ -20,8 +20,11 @@ if ($tipo !== '') {
 }
 
 if ($buscar !== '') {
-    $sql .= " AND (rut LIKE :b OR nombre LIKE :b)";
-    $params['b'] = '%' . $buscar . '%';
+    // MySQL PDO no permite reutilizar el mismo nombre de placeholder,
+    // por lo que usamos dos placeholders distintos
+    $sql .= " AND (rut LIKE :buscar_rut OR nombre LIKE :buscar_nom)";
+    $params['buscar_rut'] = '%' . $buscar . '%';
+    $params['buscar_nom'] = '%' . $buscar . '%';
 }
 
 $sql .= " ORDER BY id DESC";


### PR DESCRIPTION
## Summary
- prevent Invalid parameter number error in `operador/ver_controles.php`

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68643b2c05048326a73635cfc8b4d110