### PR TITLE
Fix missing controls fields

### DIFF
--- a/operador/registro_control.php
+++ b/operador/registro_control.php
@@ -24,7 +24,23 @@ require_once '../config.php';
         </select>
       </div>
 
+      <div id="seccion-basicos" style="display:none;">
+        <div class="form-group">
+          <label for="rut">RUT:</label>
+          <input id="rut" name="rut">
+        </div>
+        <div class="form-group">
+          <label for="nombre">Nombre:</label>
+          <input id="nombre" name="nombre">
+        </div>
+        <div class="form-group">
+          <label for="apellido">Apellido:</label>
+          <input id="apellido" name="apellido">
+        </div>
+      </div>
 
+      <div id="seccion-identidad" class="tipo-section" style="display:none;">
+        <div class="form-group">
           <label for="motivo_desplazamiento">Motivo de Desplazamiento:</label>
           <input id="motivo_desplazamiento" name="motivo_desplazamiento">
         </div>


### PR DESCRIPTION
## Summary
- restore lost RUT/Nombre/Apellido fields in operator control form

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686450856d188326afbd87f1d6d4c6fd