### PR TITLE
Set location fields as read-only

### DIFF
--- a/operador/editar_delincuente.php
+++ b/operador/editar_delincuente.php
@@ -70,7 +70,7 @@ if (!$delincuente) {
             </div>
             <div class="form-group">
                 <label for="ultimo_lugar">Último Lugar Visto:</label>
-                <input id="ultimo_lugar" name="ultimo_lugar" placeholder="seleccionalo en el mapa de abajo" required value="<?= htmlspecialchars($delincuente['ultimo_lugar_visto']) ?>">
+                <input id="ultimo_lugar" name="ultimo_lugar" placeholder="seleccionalo en el mapa de abajo" required readonly value="<?= htmlspecialchars($delincuente['ultimo_lugar_visto']) ?>">
             </div>
             <div class="form-group">
                 <label for="fono">Fono Fijo:</label>
@@ -119,11 +119,11 @@ if (!$delincuente) {
             </div>
             <div class="form-group">
                 <label for="latitud">Latitud:</label>
-                <input id="latitud" name="latitud" required value="<?= htmlspecialchars($delincuente['latitud']) ?>">
+                <input id="latitud" name="latitud" required readonly value="<?= htmlspecialchars($delincuente['latitud']) ?>">
             </div>
             <div class="form-group">
                 <label for="longitud">Longitud:</label>
-                <input id="longitud" name="longitud" required value="<?= htmlspecialchars($delincuente['longitud']) ?>">
+                <input id="longitud" name="longitud" required readonly value="<?= htmlspecialchars($delincuente['longitud']) ?>">
             </div>
             <button type="submit">Guardar Cambios</button>
         </form>

--- a/operador/registro_delincuente.php
+++ b/operador/registro_delincuente.php
@@ -39,7 +39,7 @@ $tiposDelito = $stmtTipos->fetchAll();
       </div>
       <div class="form-group">
         <label for="ultimo_lugar">Último Lugar Visto:</label>
-        <input id="ultimo_lugar" name="ultimo_lugar" placeholder="seleccionalo en el mapa de abajo" required>
+        <input id="ultimo_lugar" name="ultimo_lugar" placeholder="seleccionalo en el mapa de abajo" required readonly>
       </div>
       <div class="form-group">
         <label for="fono">Fono Fijo:</label>
@@ -85,11 +85,11 @@ $tiposDelito = $stmtTipos->fetchAll();
       </div>
       <div class="form-group">
         <label for="latitud">Latitud:</label>
-        <input id="latitud" name="latitud" placeholder="Ej: -33.4489" required>
+        <input id="latitud" name="latitud" placeholder="Ej: -33.4489" required readonly>
       </div>
       <div class="form-group">
         <label for="longitud">Longitud:</label>
-        <input id="longitud" name="longitud" placeholder="Ej: -70.6693" required>
+        <input id="longitud" name="longitud" placeholder="Ej: -70.6693" required readonly>
       </div>
       <button type="submit">Registrar Delincuente</button>
     </form>


### PR DESCRIPTION
## Summary
- make the `ultimo_lugar`, `latitud` and `longitud` inputs read-only in the offender register and edit forms

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml --no-coverage` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68647bbe00c0832683900ec6867e7e93