### PR TITLE
Make location fields read-only

### DIFF
--- a/operador/registro_control.php
+++ b/operador/registro_control.php
@@ -57,11 +57,11 @@ require_once '../config.php';
         </div>
         <div class="form-group">
           <label for="latitud">Latitud:</label>
-          <input id="latitud" name="latitud">
+          <input id="latitud" name="latitud" readonly>
         </div>
         <div class="form-group">
           <label for="longitud">Longitud:</label>
-          <input id="longitud" name="longitud">
+          <input id="longitud" name="longitud" readonly>
         </div>
       </div>
 

--- a/operador/registro_delito.php
+++ b/operador/registro_delito.php
@@ -54,11 +54,11 @@ $delincuentes = $stmtDelincuentes->fetchAll();
       </div>
       <div class="form-group">
         <label for="latitud">Latitud:</label>
-        <input id="latitud" name="latitud">
+        <input id="latitud" name="latitud" readonly>
       </div>
       <div class="form-group">
         <label for="longitud">Longitud:</label>
-        <input id="longitud" name="longitud">
+        <input id="longitud" name="longitud" readonly>
       </div>
       <div class="form-group">
         <label for="tipo_id">Tipo de Delito:</label>


### PR DESCRIPTION
## Summary
- mark latitud and longitud inputs as read-only in registro_control
- make the same change in registro_delito

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_68647d018f188326aa73ba78c3260db7