### PR TITLE
Fix crime count based on delito table

### DIFF
--- a/api/get_delitos_count.php
+++ b/api/get_delitos_count.php
@@ -1,14 +1,24 @@
 <?php
 require_once '../config.php';
 header('Content-Type: application/json');
+
 $rut = trim($_GET['rut'] ?? '');
-if ($rut === '') { echo json_encode(['count' => 0]); exit; }
-$stmt = $pdo->prepare('SELECT delitos FROM delincuente WHERE rut = ? LIMIT 1');
+if ($rut === '') {
+    echo json_encode(['count' => 0]);
+    exit;
+}
+
+// Obtener el id del delincuente para contar los delitos asociados
+$stmt = $pdo->prepare('SELECT id FROM delincuente WHERE rut = ? LIMIT 1');
 $stmt->execute([$rut]);
 $row = $stmt->fetch(PDO::FETCH_ASSOC);
-$count = 0;
-if ($row && !empty($row['delitos'])) {
-    $items = array_filter(array_map('trim', explode(',', $row['delitos'])));
-    $count = count($items);
+if (!$row) {
+    echo json_encode(['count' => 0]);
+    exit;
 }
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM delito WHERE delincuente_id = ?');
+$stmt->execute([$row['id']]);
+$count = (int)$stmt->fetchColumn();
+
 echo json_encode(['count' => $count]);

--- a/operador/descargar_historial.php
+++ b/operador/descargar_historial.php
@@ -52,11 +52,9 @@ if ($format === 'html') {
         'Celular' => $persona['celular'],
         'Email' => $persona['email'],
         'Fecha Nac.' => $persona['fecha_nacimiento'],
-        'Delitos' => (function($d){
-            if (empty($d)) return 'sin registros aun';
-            $c = count(array_filter(array_map('trim', explode(',', $d))));
+        'Delitos' => (function($c){
             return $c > 0 ? $c : 'sin registros aun';
-        })($persona['delitos']),
+        })(count($delitos)),
         'Estado' => $persona['estado'],
         'Último Lugar Visto' => $persona['ultimo_lugar_visto'],
         'Latitud' => $persona['latitud'],
@@ -141,7 +139,7 @@ fputcsv($out, [
     $persona['celular'],
     $persona['email'],
     $persona['fecha_nacimiento'],
-    $persona['delitos'],
+    count($delitos),
     $persona['estado'],
     $persona['ultimo_lugar_visto'],
     $persona['latitud'],

--- a/operador/editar_delincuente.php
+++ b/operador/editar_delincuente.php
@@ -27,10 +27,9 @@ if (!$apellidos && !$nombres && !empty($delincuente['apellidos_nombres'])) {
 }
 
 
-$delitosCount = 0;
-if (!empty($delincuente['delitos'])) {
-    $delitosCount = count(array_filter(array_map('trim', explode(',', $delincuente['delitos']))));
-}
+$stmtDelitos = $pdo->prepare('SELECT COUNT(*) FROM delito WHERE delincuente_id = ?');
+$stmtDelitos->execute([$delincuente['id']]);
+$delitosCount = (int)$stmtDelitos->fetchColumn();
 
 // Estado actual guardado en la base de datos
 $estadoActual = $delincuente['estado'] ?? '';

--- a/operador/historial_delincuente.php
+++ b/operador/historial_delincuente.php
@@ -15,7 +15,7 @@ $persona = null;
 $delitos = [];
 $controles = [];
 if ($rut) {
-    $stmt = $pdo->prepare("SELECT * FROM delincuente WHERE rut = ? LIMIT 1");
+    $stmt = $pdo->prepare("SELECT d.*, (SELECT COUNT(*) FROM delito dl WHERE dl.delincuente_id = d.id) AS delitos_count FROM delincuente d WHERE d.rut = ? LIMIT 1");
     $stmt->execute([$rut]);
     $persona = $stmt->fetch();
     if ($persona) {
@@ -65,12 +65,7 @@ if ($rut) {
           <tr><th>Celular</th><td><?= htmlspecialchars($persona['celular']) ?></td></tr>
           <tr><th>Email</th><td><?= htmlspecialchars($persona['email']) ?></td></tr>
           <tr><th>Fecha Nac.</th><td><?= htmlspecialchars($persona['fecha_nacimiento']) ?></td></tr>
-          <?php
-            $delitosCount = 0;
-            if (!empty($persona['delitos'])) {
-              $delitosCount = count(array_filter(array_map('trim', explode(',', $persona['delitos']))));
-            }
-          ?>
+          <?php $delitosCount = (int)$persona['delitos_count']; ?>
           <tr><th>Delitos</th><td><?= $delitosCount > 0 ? $delitosCount : 'sin registros aun' ?></td></tr>
           <tr><th>Estado</th><td><?= htmlspecialchars($persona['estado']) ?></td></tr>
           <tr><th>Último Lugar Visto</th><td><?= htmlspecialchars($persona['ultimo_lugar_visto']) ?></td></tr>


### PR DESCRIPTION
## Summary
- update API `get_delitos_count.php` to count rows in `delito`
- show number of delitos using subquery counts on listing and history pages
- count crimes when editing delinquents
- adjust history download to report count

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6866d4c137ec8326b7fb6393b3384a6b