### PR TITLE
Add activity logging

### DIFF
--- a/actividad/movimientos.php
+++ b/actividad/movimientos.php
@@ -1,0 +1,44 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'admin') {
+    header('Location: ../index.php');
+    exit();
+}
+require_once '../config.php';
+
+$logs = $pdo->query("SELECT da.*, u.nombre AS autor_nombre, u.rut AS autor_rut
+                      FROM delincuente_actividad da
+                      LEFT JOIN usuario u ON da.autor_id = u.id
+                      ORDER BY da.fecha DESC")->fetchAll();
+?>
+<?php include('../inc/header.php'); ?>
+<div class="wrapper">
+  <div class="content">
+    <h2>Actividad del Sistema</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Fecha</th>
+          <th>Acción</th>
+          <th>RUT Delincuente</th>
+          <th>Nombre</th>
+          <th>Datos</th>
+          <th>Autor</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($logs as $l): ?>
+        <tr>
+          <td><?= htmlspecialchars($l['fecha']) ?></td>
+          <td><?= htmlspecialchars($l['accion']) ?></td>
+          <td><?= htmlspecialchars($l['rut']) ?></td>
+          <td><?= htmlspecialchars($l['nombre']) ?></td>
+          <td><?= htmlspecialchars($l['datos']) ?></td>
+          <td><?= htmlspecialchars($l['autor_nombre']) ?> (<?= htmlspecialchars($l['autor_rut']) ?>)</td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php include('../inc/footer.php'); ?>
+</div>

--- a/actividad/usuarios.php
+++ b/actividad/usuarios.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+if (!isset($_SESSION['user_id']) || $_SESSION['rol'] !== 'admin') {
+    header('Location: ../index.php');
+    exit();
+}
+require_once '../config.php';
+
+$logs = $pdo->query("SELECT ua.*, u.nombre AS autor_nombre, u.rut AS autor_rut
+                      FROM usuario_actividad ua
+                      LEFT JOIN usuario u ON ua.autor_id = u.id
+                      ORDER BY ua.fecha DESC")->fetchAll();
+?>
+<?php include('../inc/header.php'); ?>
+<div class="wrapper">
+  <div class="content">
+    <h2>Actividad de Usuarios</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Fecha</th>
+          <th>Acción</th>
+          <th>RUT</th>
+          <th>Nombre</th>
+          <th>Rol</th>
+          <th>Datos</th>
+          <th>Autor</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($logs as $l): ?>
+        <tr>
+          <td><?= htmlspecialchars($l['fecha']) ?></td>
+          <td><?= htmlspecialchars($l['accion']) ?></td>
+          <td><?= htmlspecialchars($l['rut']) ?></td>
+          <td><?= htmlspecialchars($l['nombre']) ?></td>
+          <td><?= htmlspecialchars($l['rol']) ?></td>
+          <td><?= htmlspecialchars($l['datos']) ?></td>
+          <td><?= htmlspecialchars($l['autor_nombre']) ?> (<?= htmlspecialchars($l['autor_rut']) ?>)</td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <?php include('../inc/footer.php'); ?>
+</div>

--- a/admin/editar_usuario.php
+++ b/admin/editar_usuario.php
@@ -36,6 +36,22 @@ if ($_SERVER['REQUEST_METHOD']==='POST') {
     $params['id']=$id;
     $st=$pdo->prepare($sql);
     if ($st->execute($params)) {
+      $cambios=[];
+      if($rut!=$u['rut']) $cambios[]='rut';
+      if($nombre!=$u['nombre']) $cambios[]='nombre';
+      if($rol!=$u['rol']) $cambios[]='rol';
+      if($inst_id!=$u['institucion_id']) $cambios[]='institucion_id';
+      if($fh!=$u['fecha_habilitacion']) $cambios[]='fecha_habilitacion';
+      if(!empty($_POST['password'])) $cambios[]='password';
+      logActividadUsuario($pdo,[
+        'usuario_id'=>$id,
+        'rut'=>$rut,
+        'nombre'=>$nombre,
+        'rol'=>$rol,
+        'accion'=>'actualizado',
+        'datos'=>implode(',', $cambios),
+        'autor_id'=>$_SESSION['user_id']
+      ]);
       header("Location: gestion_usuarios.php");exit();
     } else { $error="Error al actualizar"; }
   }

--- a/admin/eliminar_usuario.php
+++ b/admin/eliminar_usuario.php
@@ -5,8 +5,21 @@ if (!isset($_SESSION['user_id'])||$_SESSION['rol']!=='admin'){
   header("Location: ../index.php");exit();
 }
 require_once '../config.php';
+require_once '../inc/funciones.php';
 $id=intval($_GET['id']??0);
+$stmt=$pdo->prepare("SELECT rut,nombre,rol FROM usuario WHERE id=:id");
+$stmt->execute(['id'=>$id]);
+$info=$stmt->fetch();
 $pdo->prepare("DELETE FROM usuario WHERE id=:id")
     ->execute(['id'=>$id]);
+logActividadUsuario($pdo,[
+  'usuario_id'=>$id,
+  'rut'=>$info['rut']??null,
+  'nombre'=>$info['nombre']??null,
+  'rol'=>$info['rol']??null,
+  'accion'=>'eliminado',
+  'datos'=>'',
+  'autor_id'=>$_SESSION['user_id']
+]);
 header("Location: gestion_usuarios.php");
 exit();

--- a/admin/nuevo_usuario.php
+++ b/admin/nuevo_usuario.php
@@ -31,6 +31,16 @@ if ($_SERVER['REQUEST_METHOD']==='POST') {
         'rut'=>$rut,'nombre'=>$nombre,'pass'=>$hash,
         'rol'=>$rol,'iid'=>$inst_id,'fh'=>$fh
       ])) {
+        $newId=$pdo->lastInsertId();
+        logActividadUsuario($pdo,[
+          'usuario_id'=>$newId,
+          'rut'=>$rut,
+          'nombre'=>$nombre,
+          'rol'=>$rol,
+          'accion'=>'creado',
+          'datos'=>'',
+          'autor_id'=>$_SESSION['user_id']
+        ]);
         header("Location: gestion_usuarios.php");exit();
       } else { $error="Error al crear usuario"; }
     }

--- a/inc/funciones.php
+++ b/inc/funciones.php
@@ -37,3 +37,19 @@ function validarRut($rut) {
     $dvCalculado = calcularDigitoVerificador($cuerpo);
     return $dvIngresado === $dvCalculado;
 }
+
+function logActividadUsuario(PDO $pdo, array $data): void {
+    $sql = "INSERT INTO usuario_actividad
+            (usuario_id, rut, nombre, rol, accion, datos, autor_id)
+            VALUES (:usuario_id, :rut, :nombre, :rol, :accion, :datos, :autor_id)";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($data);
+}
+
+function logActividadDelincuente(PDO $pdo, array $data): void {
+    $sql = "INSERT INTO delincuente_actividad
+            (delincuente_id, rut, nombre, accion, datos, autor_id)
+            VALUES (:delincuente_id, :rut, :nombre, :accion, :datos, :autor_id)";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($data);
+}

--- a/inc/header.php
+++ b/inc/header.php
@@ -80,6 +80,14 @@
   <button onclick="location.href='/reportes.php';">
     <i class="fa-solid fa-chart-simple"></i> Reportes
   </button>
+  <?php if (!empty($_SESSION['rol']) && $_SESSION['rol'] === 'admin'): ?>
+    <button onclick="location.href='/actividad/usuarios.php';">
+      <i class="fa-solid fa-list"></i> Actividad Usuarios
+    </button>
+    <button onclick="location.href='/actividad/movimientos.php';">
+      <i class="fa-solid fa-clock-rotate-left"></i> Actividad Sistema
+    </button>
+  <?php endif; ?>
   <button onclick="location.href='/mapa_delincuentes.php';">
     <i class="fa-solid fa-map-location-dot"></i> Mapa
   </button>

--- a/operador/eliminar_delincuente.php
+++ b/operador/eliminar_delincuente.php
@@ -6,12 +6,24 @@ if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'admin') {
 }
 
 require_once '../config.php';
+require_once '../inc/funciones.php';
 
 $id = $_POST['id'] ?? null;
 
 if ($id) {
+    $infoStmt=$pdo->prepare("SELECT rut,apellidos_nombres FROM delincuente WHERE id=?");
+    $infoStmt->execute([$id]);
+    $info=$infoStmt->fetch();
     $stmt = $pdo->prepare("DELETE FROM delincuente WHERE id = ?");
     $stmt->execute([$id]);
+    logActividadDelincuente($pdo,[
+      'delincuente_id'=>$id,
+      'rut'=>$info['rut']??null,
+      'nombre'=>$info['apellidos_nombres']??null,
+      'accion'=>'eliminado',
+      'datos'=>'',
+      'autor_id'=>$_SESSION['user_id']
+    ]);
 }
 
 header('Location: listado_delincuentes.php?msg=Delincuente eliminado');

--- a/operador/procesar_edicion_delincuente.php
+++ b/operador/procesar_edicion_delincuente.php
@@ -6,6 +6,7 @@ if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
 }
 
 require_once '../config.php';
+require_once '../inc/funciones.php';
 
 $imagen = $_POST['imagen_actual'] ?? null;
 if (!empty($_FILES['imagen']['name'])) {
@@ -49,6 +50,7 @@ if (!in_array($estado, $permitidos, true)) {
     exit;
 }
 
+$id=$_POST['id'];
 $stmt->execute([
     'rut' => $_POST['rut'],
     'nombres' => $_POST['nombres'],
@@ -66,7 +68,16 @@ $stmt->execute([
     'estado' => $estado,
     'latitud' => $_POST['latitud'],
     'longitud' => $_POST['longitud'],
-    'id' => $_POST['id']
+    'id' => $id
+]);
+// Registrar actividad
+logActividadDelincuente($pdo,[
+    'delincuente_id'=>$id,
+    'rut'=>$_POST['rut'],
+    'nombre'=>trim($_POST['apellidos']).' '.trim($_POST['nombres']),
+    'accion'=>'actualizado',
+    'datos'=>'',
+    'autor_id'=>$_SESSION['user_id']
 ]);
 
 header('Location: listado_delincuentes.php?msg=Delincuente actualizado');

--- a/operador/process_registro_delincuente.php
+++ b/operador/process_registro_delincuente.php
@@ -98,6 +98,15 @@ $sql="INSERT INTO delincuente
 ";
 $insert=$pdo->prepare($sql);
 if ($insert->execute($datos)) {
+  $newId=$pdo->lastInsertId();
+  logActividadDelincuente($pdo,[
+    'delincuente_id'=>$newId,
+    'rut'=>$datos['rut'],
+    'nombre'=>$datos['apellidos_nombres'],
+    'accion'=>'registrado',
+    'datos'=>'',
+    'autor_id'=>$_SESSION['user_id']
+  ]);
   header("Location: registro_delincuente.php?msg=Registrado"); exit();
 } else {
   header("Location: registro_delincuente.php?msg=Error"); exit();

--- a/schema.sql
+++ b/schema.sql
@@ -510,3 +510,30 @@ INSERT INTO comuna (nombre, latitud, longitud) VALUES
   ('San Gregorio', -52.3258, -69.5769),
   ('Timaukel', -54.0907, -68.8974),
   ('Torres del Paine', -51.0593, -73.0203);
+
+# Tabla para registrar actividad de usuarios
+CREATE TABLE IF NOT EXISTS usuario_actividad (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  usuario_id INT DEFAULT NULL,
+  rut VARCHAR(12),
+  nombre VARCHAR(100),
+  rol ENUM('admin','jefe_zona','operador'),
+  accion ENUM('creado','actualizado','eliminado') NOT NULL,
+  datos TEXT,
+  autor_id INT DEFAULT NULL,
+  fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (autor_id) REFERENCES usuario(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+
+# Tabla para registrar actividad de delincuentes
+CREATE TABLE IF NOT EXISTS delincuente_actividad (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  delincuente_id INT DEFAULT NULL,
+  rut VARCHAR(12),
+  nombre VARCHAR(150),
+  accion ENUM('registrado','actualizado','eliminado') NOT NULL,
+  datos TEXT,
+  autor_id INT DEFAULT NULL,
+  fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (autor_id) REFERENCES usuario(id) ON DELETE SET NULL
+) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- create tables for user and offender activity
- log actions when users or offenders are created, updated or deleted
- add helper functions for logging
- create pages to list recorded activities
- add new admin menu items for these pages

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6866f70092fc8326977b220a2b55a9fa