### PR TITLE
Enable control viewing for admin and zone chiefs

### DIFF
--- a/inc/header.php
+++ b/inc/header.php
@@ -74,6 +74,11 @@
       <i class="fa-solid fa-gavel"></i> Registrar Delito
     </button>
   <?php endif; ?>
+  <?php if (!empty($_SESSION['rol']) && in_array($_SESSION['rol'], ['admin', 'jefe_zona'])): ?>
+    <button onclick="location.href='/operador/ver_controles.php';">
+      <i class="fa-solid fa-eye"></i> Ver Controles
+    </button>
+  <?php endif; ?>
   <button onclick="location.href='/operador/historial_delincuente.php';">
     <i class="fa-solid fa-book"></i> Historial
   </button>

--- a/operador/ver_controles.php
+++ b/operador/ver_controles.php
@@ -1,7 +1,7 @@
 <?php
 // operador/ver_controles.php
 session_start();
-if (!isset($_SESSION['rol']) || $_SESSION['rol'] !== 'operador') {
+if (!isset($_SESSION['rol']) || !in_array($_SESSION['rol'], ['operador', 'admin', 'jefe_zona'])) {
     header('Location: /login.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- show the _Ver Controles_ sidebar button for admin and zone chief roles
- allow admin and zone chiefs to access `ver_controles.php`

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6867278beb9883269071a58e6263ce8a