### PR TITLE
Revert search form changes in mapa

### DIFF
--- a/mapa_delincuentes.php
+++ b/mapa_delincuentes.php
@@ -12,7 +12,7 @@ if (!isset($_SESSION['user_id'])) {
     <h2>Mapa de Delincuentes</h2>
 
     <!-- Formulario de Búsqueda -->
-    <form id="searchForm" class="map-search">
+    <div class="map-search">
       <label for="searchRut">RUT:</label>
       <select id="searchRut">
         <option value="">-- Selecciona un RUT --</option>
@@ -24,9 +24,9 @@ if (!isset($_SESSION['user_id'])) {
       <label for="searchApodo">Apodo:</label>
       <input type="text" id="searchApodo" placeholder="Apodo" autocomplete="off">
 
-      <button type="submit" id="searchBtn">Buscar</button>
-      <button type="button" id="resetBtn">Mostrar Todos</button>
-    </form>
+      <button id="searchBtn">Buscar</button>
+      <button id="resetBtn">Mostrar Todos</button>
+    </div>
 
     <!-- Contenedor del mapa -->
     <div id="map" style="height:500px;"></div>
@@ -112,18 +112,11 @@ if (!isset($_SESSION['user_id'])) {
       }
     });
 
-    const searchForm = document.getElementById('searchForm');
-    const handleSearch = () => {
+    document.getElementById('searchBtn').addEventListener('click', () => {
       const rut = document.getElementById('searchRut').value.trim();
       const nombre = document.getElementById('searchNombre').value.trim();
       const apodo = document.getElementById('searchApodo').value.trim();
       loadMarkers({ rut, nombre, apodo });
-    };
-
-    document.getElementById('searchBtn').addEventListener('click', handleSearch);
-    searchForm.addEventListener('submit', (e) => {
-      e.preventDefault();
-      handleSearch();
     });
 
     document.getElementById('resetBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- revert search box from `<form>` to `<div>` layout
- remove handleSearch logic so buttons work as before

## Testing
- `composer install`
- `vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_68673751b5188326911d662e3533425f