### PR TITLE
Remove download link for historial

### DIFF
--- a/operador/historial_delincuente.php
+++ b/operador/historial_delincuente.php
@@ -52,7 +52,7 @@ if ($rut) {
     </form>
 
     <?php if ($rut && $persona): ?>
-      <a href="descargar_historial.php?rut=<?= urlencode($rut) ?>&format=html" target="_blank">Descargar Reporte</a>
+      <a href="descargar_historial.php?rut=<?= urlencode($rut) ?>&format=html" target="_blank">Imprimir</a>
       <h3>Datos Personales</h3>
       <table>
         <tbody>


### PR DESCRIPTION
## Summary
- replace "Descargar Reporte" link with "Imprimir" on the delinquent history page

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68673aafe4048326947c492fbfce6852