### PR TITLE
Remove unneeded conductor fields

### DIFF
--- a/operador/registro_control.php
+++ b/operador/registro_control.php
@@ -78,14 +78,6 @@ require_once '../config.php';
           <label for="revision_seguro">Revisión Técnica / SOAP:</label>
           <input id="revision_seguro" name="revision_seguro">
         </div>
-        <div class="form-group">
-          <label for="rut_conductor">RUT del Conductor:</label>
-          <input id="rut_conductor" name="rut_conductor">
-        </div>
-        <div class="form-group">
-          <label for="nombre_conductor">Nombre del Conductor:</label>
-          <input id="nombre_conductor" name="nombre_conductor">
-        </div>
       </div>
 
       <div id="seccion-armas" class="tipo-section" style="display:none;">


### PR DESCRIPTION
## Summary
- remove RUT/NOMBRE conductor fields from vehicular control form

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6867489a0b7483269f2fa4b5eed5d140