### PR TITLE
Revert navigation colors and keep content styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap");
-:root{--primary-color:#6200ee;--secondary-color:#03dac6;--background-color:#f5f5f5;--surface-color:#fff;--text-color:#333;}
+:root{--primary-color:#004466;--secondary-color:#0066aa;--background-color:#f2f2f2;--surface-color:#fff;--text-color:#333;}
 /* css/style.css */
 
 /* Reset global */
@@ -94,7 +94,7 @@
     position: fixed;
     top: 60px; left: 0; bottom: 0;
     width: 15%;
-    background: #3700b3;
+    background: #003355;
     overflow-y: auto;
     transition: transform 0.3s ease;
     z-index: 1100; /* sobreponer el contenido principal */
@@ -110,7 +110,7 @@
     margin: 0px auto;
     padding: 15px;
     border: none;
-    background: var(--primary-color);
+    background: #00335d;
     color: #fff;
     font-size: 16px;
     text-align: left;
@@ -130,7 +130,7 @@
  /* se mueve 5px hacia la derecha */
  transform: translateX(5px);
  /* oscurece ligeramente el fondo al pasar el mouse */
- background-color: #3700b3;
+ background-color: #0066aa;
 }
 
 
@@ -212,7 +212,7 @@
   transition: background-color 0.2s ease;
 }
 .map-search button:hover {
-  background-color: #6200ee;
+  background-color: #005599;
 }
 
 


### PR DESCRIPTION
## Summary
- restore original color palette for header, sidebar and footer
- keep modern content styling using the previous palette

## Testing
- `composer install`
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6868a975991c83269e41f3111ad61f0b